### PR TITLE
refactor(ui): remove obsolete TinyMCE styles and add new table and link styling

### DIFF
--- a/colors/page-general.js
+++ b/colors/page-general.js
@@ -340,40 +340,8 @@
                 --tw-ring-color: ${palette[800]} !important;
             }
 
-            .tox .tox-statusbar {
-                background-color: ${palette[800]} !important;
-                border-top: 1px solid ${palette[600]} !important;
-                color: ${palette[200]} !important;
-            }
-
-            #tinymce {
-                background-color: ${palette[800]} !important;
-            }
-
             #mainpart.custome-page, #mainpart.page-board {
                 background-color: ${palette[900]} !important;
-            }
-
-            .tox .tox-toolbar, .tox .tox-toolbar__overflow, .tox .tox-toolbar__primary {
-                background-color: ${palette[800]} !important;
-            }
-
-            .tox:not(.tox-tinymce-inline) .tox-editor-header {
-                background-color: ${palette[800]} !important;
-                border-bottom: 1px solid ${palette[600]} !important;
-            }
-
-            .tox .tox-tbtn:hover {
-                background: ${palette[700]} !important;
-            }
-
-            .tox .tox-tbtn {
-                background: ${palette[800]} !important;
-            }
-
-            .tox .tox-tbtn--active, .tox .tox-tbtn--enabled, .tox .tox-tbtn--enabled:focus, .tox .tox-tbtn--enabled:hover {
-                background: ${palette[500]} !important;
-                color: ${textColor} !important;
             }
 
             .button-green {
@@ -409,6 +377,23 @@
             body {
                 background-color: ${palette[900]} !important;
                 color: ${palette[100]} !important;
+            }
+
+            table.listext-table tr th {
+                background-color: ${palette[700]} !important;
+                color: ${palette[300]} !important;
+            }
+
+            .user-private-tabs li:hover {
+                background-color: ${palette[700]} !important;
+            }
+
+            table.listext-table tr:hover {
+                background-color: ${palette[600]} !important;
+            }
+
+            .action-link {
+                color: ${palette[500]} !important;
             }
         `;
 
@@ -692,42 +677,6 @@
                 --tw-ring-color: ${defaultPalette[800]} !important;
             }
 
-            .tox .tox-statusbar {
-                background-color: ${defaultPalette[800]} !important;
-                border-top: 1px solid ${defaultPalette[600]} !important;
-                color: ${defaultPalette[200]} !important;
-            }
-
-            #tinymce {
-                background-color: ${defaultPalette[800]} !important;
-            }
-
-            #mainpart.custome-page, #mainpart.page-board {
-                background-color: ${defaultPalette[900]} !important;
-            }
-
-            .tox .tox-toolbar, .tox .tox-toolbar__overflow, .tox .tox-toolbar__primary {
-                background-color: ${defaultPalette[800]} !important;
-            }
-
-            .tox:not(.tox-tinymce-inline) .tox-editor-header {
-                background-color: ${defaultPalette[800]} !important;
-                border-bottom: 1px solid ${defaultPalette[600]} !important;
-            }
-
-            .tox .tox-tbtn:hover {
-                background: ${defaultPalette[700]} !important;
-            }
-
-            .tox .tox-tbtn {
-                background: ${defaultPalette[800]} !important;
-            }
-
-            .tox .tox-tbtn--active, .tox .tox-tbtn--enabled, .tox .tox-tbtn--enabled:focus, .tox .tox-tbtn--enabled:hover {
-                background: ${defaultColor} !important;
-                color: #fff !important;
-            }
-
             .button-green {
                 background-color: ${defaultPalette[400]} !important;
                 border-color: ${defaultPalette[600]} !important;
@@ -761,6 +710,23 @@
             body {
                 background-color: ${defaultPalette[900]} !important;
                 color: ${defaultPalette[100]} !important;
+            }
+
+            table.listext-table tr th {
+                background-color: ${defaultPalette[700]} !important;
+                color: ${defaultPalette[300]} !important;
+            }
+
+            .user-private-tabs li:hover {
+                background-color: ${defaultPalette[700]} !important;
+            }
+
+            table.listext-table tr:hover {
+                background-color: ${defaultPalette[600]} !important;
+            }
+
+            .action-link {
+                color: ${defaultColor} !important;
             }
         `;
 

--- a/colors/page-info-truyen.js
+++ b/colors/page-info-truyen.js
@@ -696,41 +696,6 @@
                 color: ${textColor} !important;
             }
 
-            .tox .tox-statusbar {
-                background-color: ${palette[800]} !important;
-                border-top: 1px solid ${palette[600]} !important;
-                color: ${palette[200]} !important;
-            }
-
-            #tinymce {
-                background-color: ${palette[800]} !important;
-            }
-
-            .tox:not(.tox-tinymce-inline) .tox-editor-header {
-                background-color: ${palette[800]} !important;
-                border-bottom: 1px solid ${palette[600]} !important;
-            }
-
-            .tox .tox-tbtn {
-                background: ${palette[800]} !important;
-                color: ${textColor} !important;
-            }
-
-            .tox .tox-tbtn:hover {
-                background: ${palette[700]} !important;
-                color: ${textColor} !important;
-            }
-
-            .tox .tox-tbtn--active, .tox .tox-tbtn--enabled, .tox .tox-tbtn--enabled:focus, .tox .tox-tbtn--enabled:hover {
-                background: ${palette[500]} !important;
-                color: ${textColor} !important;
-            }
-
-            .tox .tox-tbtn--disabled, .tox .tox-tbtn--disabled:hover, .tox .tox-tbtn:disabled, .tox .tox-tbtn:disabled:hover {
-                background: ${palette[800]} !important;
-                color: ${palette[300]} !important;
-            }
-
             :is(.dark .dark\:ring-cyan-900) {
                 --tw-ring-color: ${palette[800]} !important;
             }
@@ -944,41 +909,6 @@
                 background-color: ${defaultPalette[400]} !important;
                 border-color: ${defaultPalette[600]} !important;
                 color: #fff !important;
-            }
-
-            .tox .tox-statusbar {
-                background-color: ${defaultPalette[800]} !important;
-                border-top: 1px solid ${defaultPalette[600]} !important;
-                color: ${defaultPalette[200]} !important;
-            }
-
-            #tinymce {
-                background-color: ${defaultPalette[800]} !important;
-            }
-
-            .tox:not(.tox-tinymce-inline) .tox-editor-header {
-                background-color: ${defaultPalette[800]} !important;
-                border-bottom: 1px solid ${defaultPalette[600]} !important;
-            }
-
-            .tox .tox-tbtn {
-                background: ${defaultPalette[800]} !important;
-                color: #fff !important;
-            }
-
-            .tox .tox-tbtn:hover {
-                background: ${defaultPalette[700]} !important;
-                color: #fff !important;
-            }
-
-            .tox .tox-tbtn--active, .tox .tox-tbtn--enabled, .tox .tox-tbtn--enabled:focus, .tox .tox-tbtn--enabled:hover {
-                background: ${defaultColor} !important;
-                color: #fff !important;
-            }
-
-            .tox .tox-tbtn--disabled, .tox .tox-tbtn--disabled:hover, .tox .tox-tbtn:disabled, .tox .tox-tbtn:disabled:hover {
-                background: ${defaultPalette[800]} !important;
-                color: ${defaultPalette[300]} !important;
             }
 
             :is(.dark .dark\:ring-cyan-900) {


### PR DESCRIPTION
Removed TinyMCE editor-related CSS rules from both palette and defaultPalette sections in page-general.js and page-info-truyen.js, as they are no longer needed. Added new styling for table headers, hover effects on private tabs, table row hovers, and action links to improve UI consistency and readability.

## 📝 Mô tả thay đổi
Mô tả rõ ràng và ngắn gọn những thay đổi trong PR này.

## 🔗 Liên kết Issue
Closes #(số issue)

## ✅ Kiểm tra
- [ ] Đã test trên Chrome
- [ ] Đã test trên Firefox
- [ ] Đã test trên Tampermonkey
- [ ] Đã test trên Violentmonkey
- [ ] Đã kiểm tra không có lỗi console

## 🖼️ Screenshots (nếu có)
Thêm screenshots để minh họa thay đổi trước/sau nếu có.

## 📋 Các thay đổi
- [ ] Bug fix (thay đổi không phá vỡ tính tương thích)
- [ ] New feature (thay đổi không phá vỡ tính tương thích)
- [ ] Breaking change (sửa đổi sẽ gây ra thay đổi tính tương thích)
- [ ] Chỉnh sửa tài liệu

## 🌐 Môi trường test
 - **OS:** [e.g. Windows 10, macOS Monterey, Ubuntu 20.04]
 - **Browser:** [e.g. Chrome 96, Firefox 94, Safari 15]
 - **Userscript Manager:** [e.g. Tampermonkey 4.15, Violentmonkey 2.13]

## 📝 Additional Notes
Thêm bất kỳ ghi chú nào khác về PR này.