### PR TITLE
refactor(ui): optimize color picker initialization

### DIFF
--- a/module/config.js
+++ b/module/config.js
@@ -488,6 +488,9 @@
             return;
         }
 
+        // Lấy màu hiện tại để hiển thị trong dialog
+        const currentColor = getDefaultColor();
+
         const dialog = document.createElement('div');
         dialog.className = 'hmt-config-dialog';
         dialog.innerHTML = `
@@ -1313,7 +1316,8 @@
 
         document.body.appendChild(dialog);
 
-        // Load custom presets sẽ được gọi trong setupConfigEventListeners
+        // Load custom presets với màu hiện tại
+        loadCustomPresets(dialog);
 
          // Đóng color picker panel nếu đang mở khi khởi tạo
          const colorPickerPanel = dialog.querySelector('.hmt-color-picker-panel');
@@ -1349,8 +1353,7 @@
         const resetBtn = dialog.querySelector('.hmt-config-reset');
         const colorPickerPanel = dialog.querySelector('.hmt-color-picker-panel');
 
-        // Lưu màu hiện tại để có thể khôi phục nếu không lưu
-        const currentColor = getDefaultColor();
+        // Sử dụng màu hiện tại từ createConfigDialog
         let previewColor = currentColor; // Màu đang preview
 
         debugLog('Config dialog được mở với màu hiện tại:', currentColor);
@@ -1399,9 +1402,6 @@
                 }
             }
         });
-
-        // Load custom presets sau khi đã có currentColor
-        loadCustomPresets(dialog);
 
         // Gọi hàm gắn sự kiện global
         attachPresetEvents();


### PR DESCRIPTION
Move currentColor setup earlier in createConfigDialog to avoid duplication and ensure presets load with the correct color. This improves code efficiency and consistency in the UI configuration flow.

## 📝 Mô tả thay đổi
Mô tả rõ ràng và ngắn gọn những thay đổi trong PR này.

## 🔗 Liên kết Issue
Closes #(số issue)

## ✅ Kiểm tra
- [ ] Đã test trên Chrome
- [ ] Đã test trên Firefox
- [ ] Đã test trên Tampermonkey
- [ ] Đã test trên Violentmonkey
- [ ] Đã kiểm tra không có lỗi console

## 🖼️ Screenshots (nếu có)
Thêm screenshots để minh họa thay đổi trước/sau nếu có.

## 📋 Các thay đổi
- [ ] Bug fix (thay đổi không phá vỡ tính tương thích)
- [ ] New feature (thay đổi không phá vỡ tính tương thích)
- [ ] Breaking change (sửa đổi sẽ gây ra thay đổi tính tương thích)
- [ ] Chỉnh sửa tài liệu

## 🌐 Môi trường test
 - **OS:** [e.g. Windows 10, macOS Monterey, Ubuntu 20.04]
 - **Browser:** [e.g. Chrome 96, Firefox 94, Safari 15]
 - **Userscript Manager:** [e.g. Tampermonkey 4.15, Violentmonkey 2.13]

## 📝 Additional Notes
Thêm bất kỳ ghi chú nào khác về PR này.