### PR TITLE
refactor(ui): remove color preset handling in config

### DIFF
--- a/module/config.js
+++ b/module/config.js
@@ -652,8 +652,6 @@
     function setupConfigEventListeners(dialog) {
         const closeBtn = dialog.querySelector('.hmt-config-close');
         const overlay = dialog.querySelector('.hmt-config-overlay');
-        const colorPresets = dialog.querySelectorAll('.hmt-color-preset');
-        const colorPicker = dialog.querySelector('.hmt-color-picker');
         const colorText = dialog.querySelector('.hmt-color-text');
         const previewBox = dialog.querySelector('.hmt-preview-box');
         const saveBtn = dialog.querySelector('.hmt-config-save');
@@ -772,15 +770,9 @@
              if (colorText) colorText.value = hex;
              if (previewBox) previewBox.style.backgroundColor = hex;
 
-             // Bỏ active cho tất cả presets nếu đang chọn màu tùy chỉnh
-             colorPresets.forEach(p => p.classList.remove('active'));
-
              // Áp dụng màu preview ngay lập tức
              previewColor = hex;
              applyPreviewColor(hex);
-
-             // Cập nhật trạng thái nút save
-             updateSavePresetButton(dialog);
 
              debugLog('Đã cập nhật UI từ HSL picker:', hex);
          }
@@ -919,9 +911,6 @@
                  if (colorPreview) colorPreview.style.backgroundColor = color;
                  if (colorValue) colorValue.textContent = color;
 
-                 // Bỏ active cho tất cả presets vì đang nhập màu tùy chỉnh
-                 colorPresets.forEach(p => p.classList.remove('active'));
-
                  // Áp dụng màu preview ngay lập tức
                  previewColor = color;
                  applyPreviewColor(color);
@@ -933,9 +922,6 @@
              } else {
                  debugLog('Màu không hợp lệ từ text input');
              }
-
-             // Cập nhật trạng thái nút save
-             updateSavePresetButton(dialog);
          });
 
         // Lưu cài đặt
@@ -968,11 +954,7 @@
                      colorPickerPanel.classList.remove('open');
                  }
 
-                 // Gắn lại sự kiện sau khi lỗi
-                 setTimeout(() => {
-                     attachPresetEvents();
-                     attachDeleteEvents();
-                 }, 100);
+                 // Không cần gắn lại sự kiện vì đã loại bỏ preset
              }
          });
 


### PR DESCRIPTION
Remove handling for color presets and related event listeners in the config module to simplify color picker functionality and eliminate unused code paths. This refactoring aligns with recent optimizations to the color picker initialization and UI synchronization.

## 📝 Mô tả thay đổi
Mô tả rõ ràng và ngắn gọn những thay đổi trong PR này.

## 🔗 Liên kết Issue
Closes #(số issue)

## ✅ Kiểm tra
- [ ] Đã test trên Chrome
- [ ] Đã test trên Firefox
- [ ] Đã test trên Tampermonkey
- [ ] Đã test trên Violentmonkey
- [ ] Đã kiểm tra không có lỗi console

## 🖼️ Screenshots (nếu có)
Thêm screenshots để minh họa thay đổi trước/sau nếu có.

## 📋 Các thay đổi
- [ ] Bug fix (thay đổi không phá vỡ tính tương thích)
- [ ] New feature (thay đổi không phá vỡ tính tương thích)
- [ ] Breaking change (sửa đổi sẽ gây ra thay đổi tính tương thích)
- [ ] Chỉnh sửa tài liệu

## 🌐 Môi trường test
 - **OS:** [e.g. Windows 10, macOS Monterey, Ubuntu 20.04]
 - **Browser:** [e.g. Chrome 96, Firefox 94, Safari 15]
 - **Userscript Manager:** [e.g. Tampermonkey 4.15, Violentmonkey 2.13]

## 📝 Additional Notes
Thêm bất kỳ ghi chú nào khác về PR này.