### PR TITLE
fix(profile-cropper): fix file input click handler interference

### DIFF
--- a/module/profile-cropper.js
+++ b/module/profile-cropper.js
@@ -1173,8 +1173,23 @@
         // File upload handler
         fileBtn.addEventListener('click', () => {
             closeModal();
+            // Temporarily remove our click handler to allow normal file input behavior
+            const originalClickHandler = function(e) {
+                e.preventDefault();
+                e.stopPropagation();
+                createMethodSelectionDialog(input);
+            };
+            
+            // Remove our click handler temporarily
+            input.removeEventListener('click', originalClickHandler);
+            
             // Trigger the original file input
             input.click();
+            
+            // Re-add our click handler after a short delay
+            setTimeout(() => {
+                input.addEventListener('click', originalClickHandler);
+            }, 100);
         });
 
         // URL upload handler


### PR DESCRIPTION
The file input click handler was preventing normal file input behavior when triggered programmatically. This caused issues when trying to open the file dialog through the modal's file button.

The fix temporarily removes the custom click handler before triggering the input click, then re-adds it after a short delay to restore normal functionality.

## 📝 Mô tả thay đổi
Mô tả rõ ràng và ngắn gọn những thay đổi trong PR này.

## 🔗 Liên kết Issue
Closes #(số issue)

## ✅ Kiểm tra
- [ ] Đã test trên Chrome
- [ ] Đã test trên Firefox
- [ ] Đã test trên Tampermonkey
- [ ] Đã test trên Violentmonkey
- [ ] Đã kiểm tra không có lỗi console

## 🖼️ Screenshots (nếu có)
Thêm screenshots để minh họa thay đổi trước/sau nếu có.

## 📋 Các thay đổi
- [ ] Bug fix (thay đổi không phá vỡ tính tương thích)
- [ ] New feature (thay đổi không phá vỡ tính tương thích)
- [ ] Breaking change (sửa đổi sẽ gây ra thay đổi tính tương thích)
- [ ] Chỉnh sửa tài liệu

## 🌐 Môi trường test
 - **OS:** [e.g. Windows 10, macOS Monterey, Ubuntu 20.04]
 - **Browser:** [e.g. Chrome 96, Firefox 94, Safari 15]
 - **Userscript Manager:** [e.g. Tampermonkey 4.15, Violentmonkey 2.13]

## 📝 Additional Notes
Thêm bất kỳ ghi chú nào khác về PR này.